### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,10 @@ cmake_minimum_required(VERSION 3.5.0)
 set(EXTENSION_NAME SlicerLayoutButtons)
 set(EXTENSION_HOMEPAGE "https://github.com/QIICR/SlicerLayoutButtons")
 set(EXTENSION_CATEGORY "Informatics")
-set(EXTENSION_CONTRIBUTORS "Christian Herz (SPL), Andrey Fedorov (SPL)")
-set(EXTENSION_DESCRIPTION "Simplified widget for accessing volumes and labelmaps displayed in slice views")
+set(EXTENSION_CONTRIBUTORS "Christian Herz (SPL, BWH), Andrey Fedorov (SPL, BWH)")
+set(EXTENSION_DESCRIPTION "Simplified widget for accessing volumes and labelmaps displayed in slice views.
+
+This extension provides a user interface with buttons organized the same way as the Slicer slice views are aligned. The user can directly select foreground/background volume and label map to be displayed in the associated slice view.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/QIICR/SlicerLayoutButtons/master/Resources/Icons/SlicerLayoutButtons.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/QIICR/SlicerLayoutButtons/master/Resources/Screenshots/overview.png")
 set(EXTENSION_STATUS "Work in progress")


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.